### PR TITLE
Add Implementations section, with link to rockstar-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,3 +241,6 @@ Whisper my world
 * Explore other ideas for Turing-complete rock ballad compilers. Maybe something based on BF where we use word length or initial letters or something to compile lyrics down to BF or some other very minimalist but Turing-complete language
 * Make 'Certified Rockstar Developer' stickers and give them out to anybody who can write even one line of Rockstar.
 * Generate a score for the lyrics using a component called a `composer`.
+
+# Implementations
+* [rockstar-js](https://github.com/wolfgang42/rockstar-js) - Rockstar-to-JavaScript transpiler


### PR DESCRIPTION
I'm working on a Rockstar interpreter, so I thought I'd add it to this repo.

Others (#26, #27) are sending PRs for their code directly; I didn't want to burden this repo with an implementation which would need to be maintained whenever the spec changes.