### PR TITLE
Add Kaiser-Ruby to implementation list

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Whisper my world
 * [rockstar-lexer](https://github.com/aitorres/rockstar-lexer) - Rockstar lexer written in Haskell with Alex
 * [rockstar-java](https://github.com/nbrevu/rockstar-java) - Rockstar interpreter in Java
 * [rockstar-py](https://github.com/yanorestes/rockstar-py) - Rockstar-to-Python transpiler
+* [kaiser-ruby](https://github.com/marcinruszkiewicz/kaiser-ruby) - Rockstar to Ruby transpiler
 * [sublime-rockstar-syntax](https://github.com/paxromana96/sublime-rockstar-syntax) - Syntax highlighter for Sublime Text 3
 * [maiden](https://github.com/palfrey/maiden) - Rockstar interpreter in Rust
 * [rockstar-webpiler](https://github.com/cwfitzgerald/rockstar-webpiler) - Online Rockstar Parser and Transpiler. [rockstar.connorwfitzgerald.com](https://rockstar.connorwfitzgerald.com)


### PR DESCRIPTION
This is an implementation of a Rockstar to Ruby transpiler, which is obviously named Kaiser-Ruby, because what else could I name a thing like that.

It's currently a work in progress, however most of the language features are already implemented and the two examples in my repository (FizzBuzz from this readme and Fibonacci generator from one of the issues here) are working, can be transpiled into Ruby code, and executed correctly.

Also what is worth mentioning, due to Ruby being really Unicode friendly, it handles Metal Umlauts #83 both in values and in variable names, because why not. Also now has a REPL #119, because again, why not.