### PR TITLE
Fixed specification of poetic type literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Rockstar also supports a unique language feature known as **poetic literals**. I
 
 ##### Poetic Type Literals
 
-For the keywords `true`, `false`, `nothing`, `nobody` and `nowhere`, a poetic assignment is a single line consisting of a variable name, the `is` keyword and the required value literal
+For the keywords `true`, `false`, `nothing`, `nobody`, `nowhere`, `empty`, `wrong`, `gone`, `no`, `lies`, `right`, `yes`, `ok` and `mysterious`, a poetic assignment is a single line consisting of a variable name, the `is` keyword and the required value literal
 
 * `My heart is true` - initialises the variable `my heart` with the Boolean value `true` 
 * `Tommy is nobody` - initialises the variable `Tommy` with the value `null` using the `nobody` alias


### PR DESCRIPTION
The poetic type literals specs, as of right now, specifies it being only for these keywords: `true`, `false`, `nothing`, `nobody` and `nowhere`

This PR fix this, adding other poetic type literals keywords to this list (now `My heart is empty` example makes sense)