### PR TITLE
Remove keyword from pronoun test variable name

### DIFF
--- a/tests/correct/pronouns.rock
+++ b/tests/correct/pronouns.rock
@@ -15,5 +15,5 @@ Taking is true
 put "yes" into him
 say Taking
 
-put 5 into While The World Turns
+put 5 into The World Turns
 say it


### PR DESCRIPTION
As `while` is a keyword, it can't be used to start a Proper variable