### PR TITLE
Add parsing function for put statement, fix bug with SourceLocation extend_self

### DIFF
--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -40,7 +40,7 @@ class SourceLocation:
         :param that:    Other SourceLocation
         """
         self.line_start, self.char_start = min((self.line_start, self.char_start), (that.line_start, that.char_start))
-        self.line_end, self.char_end = min((self.line_end, self.char_end), (that.line_end, that.char_end))
+        self.line_end, self.char_end = max((self.line_end, self.char_end), (that.line_end, that.char_end))
 
 
 class RockstarError(Exception):


### PR DESCRIPTION
This adds a `put_statement` function to the parser for parsing assignments using the put...into syntax. I also added a helper function for generating errors when a token is missing. The error message explains the missing token as well as the one that was found instead.

This also includes a minor fix for SourceLocation's `extend_self` function, which was incorrectly using min instead of max for determining the char and line end.
